### PR TITLE
Use new flux fp8 model

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -49,7 +49,7 @@ def load_models():
     try:
         print("Loading FLUX model...")
         flux_pipeline = FluxPipeline.from_pretrained(
-            "black-forest-labs/FLUX.1-schnell",
+            "Kijai/flux-fp8",
             torch_dtype=torch.bfloat16,
         )
         flux_pipeline.enable_model_cpu_offload()


### PR DESCRIPTION
## Summary
- load `Kijai/flux-fp8` model in `run_api`

## Testing
- `python -m py_compile run_api.py call_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6856df86e3c48323bf0f9d5b69c177a9