### PR TITLE
Add seed option to requests

### DIFF
--- a/call_api.py
+++ b/call_api.py
@@ -1,16 +1,24 @@
+import argparse
 import requests
 import base64
 from PIL import Image
 from io import BytesIO
 
-api_url = "http://localhost:5000/generate_and_upscale"
-prompt = "A vibrant coral reef with colorful fish and sunlight streaming through the water, highly detailed, underwater photography."
+parser = argparse.ArgumentParser(description="Call the diffusion API")
+parser.add_argument("prompt", help="Text prompt for image generation")
+parser.add_argument("--seed", type=int, help="Optional seed for generation")
+parser.add_argument("--url", default="http://localhost:5000/generate_and_upscale", help="API URL")
 
-payload = {"prompt": prompt}
+args = parser.parse_args()
+
+payload = {"prompt": args.prompt}
+if args.seed is not None:
+    payload["seed"] = args.seed
+
 headers = {"Content-Type": "application/json"}
 
-print(f"Sending request for prompt: {prompt}")
-response = requests.post(api_url, json=payload, headers=headers)
+print(f"Sending request for prompt: {args.prompt} with seed: {payload.get('seed', 'random')}")
+response = requests.post(args.url, json=payload, headers=headers)
 
 if response.status_code == 200:
     result = response.json()

--- a/run_api.py
+++ b/run_api.py
@@ -106,13 +106,21 @@ def generate_image():
         return jsonify({"error": "Invalid request: 'prompt' field is required in JSON body."}), 400
 
     prompt = data['prompt']
-    print(f"Received request for base generation with prompt: '{prompt}'")
+    seed = data.get('seed')
+    if seed is None:
+        seed = random.randint(0, 2**32 - 1)
+        print(f"No seed provided. Using random seed: {seed}")
+    else:
+        try:
+            seed = int(seed)
+        except (ValueError, TypeError):
+            return jsonify({"error": "Seed must be an integer."}), 400
+        print(f"Using provided seed: {seed}")
+    print(f"Received request for base generation with prompt: '{prompt}' and seed: {seed}")
 
     try:
         # Generate the image
-        print(f"Generating image for prompt: '{prompt}'")
-        seed = random.randint(0, 2**32 - 1)
-        print(f"Using random seed: {seed}")
+        print(f"Generating image for prompt: '{prompt}' with seed: {seed}")
         generated_image = flux_pipeline(
             prompt=prompt,
             height=1024,
@@ -153,13 +161,21 @@ def generate_and_upscale_image():
         return jsonify({"error": "Invalid request: 'prompt' field is required in JSON body."}), 400
 
     prompt = data['prompt']
-    print(f"Received request for generation with prompt: '{prompt}'")
+    seed = data.get('seed')
+    if seed is None:
+        seed = random.randint(0, 2**32 - 1)
+        print(f"No seed provided. Using random seed: {seed}")
+    else:
+        try:
+            seed = int(seed)
+        except (ValueError, TypeError):
+            return jsonify({"error": "Seed must be an integer."}), 400
+        print(f"Using provided seed: {seed}")
+    print(f"Received request for generation with prompt: '{prompt}' and seed: {seed}")
 
     try:
         # Generate the image with FLUX
-        print(f"Generating image for prompt: '{prompt}'")
-        seed = random.randint(0, 2**32 - 1)
-        print(f"Using random seed: {seed}")
+        print(f"Generating image for prompt: '{prompt}' with seed: {seed}")
         upscaled_image = flux_pipeline(
             prompt=prompt,
             height=1024,


### PR DESCRIPTION
## Summary
- allow clients to optionally specify a seed in API requests
- expose seed argument in the example client script

## Testing
- `python -m py_compile run_api.py call_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6858211c41d88323b36f2a788fba2a62