### PR TITLE
Add image caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Diffusion API
+
+This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
+
+Generated images are cached on disk under `generated_images/`. When a request is made with the same prompt and seed combination, the API returns the cached image instead of re-running the model.
+
+Run the API with:
+
+```bash
+python run_api.py
+```
+
+Use the helper script to call the API:
+
+```bash
+python call_api.py "an astronaut riding a horse" --seed 42
+```


### PR DESCRIPTION
## Summary
- persist generated images in `generated_images/`
- reuse cached result when prompt and seed match
- document caching behaviour in README

## Testing
- `python -m py_compile run_api.py call_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68583ca1097883239b696fdc2b44bcb6