### PR TITLE
Add optional xformers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ Use the helper script to call the API:
 ```bash
 python call_api.py "an astronaut riding a horse" --seed 42
 ```
+
+If the optional `xformers` package is installed, the API will automatically
+enable memory efficient attention for reduced GPU memory usage. Install it with:
+
+```bash
+pip install xformers
+```

--- a/run_api.py
+++ b/run_api.py
@@ -83,6 +83,17 @@ def load_models():
         flux_pipeline.text_encoder_2.to("cpu")
 
         flux_pipeline.enable_model_cpu_offload()
+
+        # Enable memory efficient attention if xformers is installed
+        try:
+            import xformers  # noqa: F401
+            flux_pipeline.enable_xformers_memory_efficient_attention()
+            print("Enabled xformers memory efficient attention.")
+        except ImportError:
+            print("xformers not installed; skipping memory efficient attention.")
+        except Exception as xf_err:
+            print(f"Unable to enable xformers memory efficient attention: {xf_err}")
+
         print("FLUX model loaded successfully.")
 
         models_loaded = True


### PR DESCRIPTION
## Summary
- optionally enable xformers memory-efficient attention in `run_api.py`
- document xformers usage in the README

## Testing
- `python -m py_compile run_api.py call_api.py`


------
https://chatgpt.com/codex/tasks/task_e_685b9f2775dc8323b86a6c291cde6650