### PR TITLE
Switch API to HiDream-I1-Fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Diffusion API
 
-This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
+This repository provides a simple Flask API for generating images using the **HiDream-I1-Fast** diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
 
 Generated images are cached on disk under `generated_images/`. When a request is made with the same prompt and seed combination, the API returns the cached image instead of re-running the model.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Run the API with:
 python run_api.py
 ```
 
+To load the model from a custom location, set the `HIDREAM_REPO` environment
+variable to a local directory or alternate Hugging Face repository before
+starting the server.
+
 Use the helper script to call the API:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository provides a simple Flask API for generating images using the **HiDream-I1-Fast** diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
 
+If running with PyTorch 2.0 or later, the UNet is compiled with `torch.compile` when the API starts for faster inference.
+
 Generated images are cached on disk under `generated_images/`. When a request is made with the same prompt and seed combination, the API returns the cached image instead of re-running the model.
 
 Run the API with:

--- a/run_api.py
+++ b/run_api.py
@@ -62,6 +62,14 @@ def load_models():
             use_safetensors=True,
         )
 
+        # Compile the UNet with torch.compile for speed if available
+        if hasattr(torch, "compile"):
+            try:
+                hidream_pipeline.unet = torch.compile(hidream_pipeline.unet)
+                print("UNet compiled with torch.compile.")
+            except Exception as ce:
+                print(f"torch.compile failed: {ce}. Proceeding without compilation.")
+
         # Enable CPU offload if available (works with accelerate)
         hidream_pipeline.enable_model_cpu_offload()
         print("HiDream model loaded successfully.")

--- a/run_api.py
+++ b/run_api.py
@@ -58,7 +58,6 @@ def load_models():
         hidream_pipeline = DiffusionPipeline.from_pretrained(
             hidream_repo,
             torch_dtype=dtype,
-            variant="fp16",
             use_safetensors=True,
         )
 

--- a/run_api.py
+++ b/run_api.py
@@ -52,11 +52,14 @@ def load_models():
     try:
         print("Loading HiDream-I1-Fast model components...")
 
-        hidream_repo = "HiDream-ai/HiDream-I1-Fast"
+        hidream_repo = os.environ.get("HIDREAM_REPO", "HiDream-ai/HiDream-I1-Fast")
         dtype = torch.float16
 
         hidream_pipeline = DiffusionPipeline.from_pretrained(
-            hidream_repo, torch_dtype=dtype
+            hidream_repo,
+            torch_dtype=dtype,
+            variant="fp16",
+            use_safetensors=True,
         )
 
         # Enable CPU offload if available (works with accelerate)
@@ -68,7 +71,7 @@ def load_models():
 
     except Exception as e:
         print(f"Error loading models: {e}")
-        print("Please check your environment, driver setup, and ensure sufficient memory.")
+        print("Set the HIDREAM_REPO environment variable to a local path or accessible Hugging Face repo if downloads fail.")
         models_loaded = False
 
 # --- API Endpoints ---


### PR DESCRIPTION
## Summary
- load the HiDream I1 Fast model instead of Flux
- update endpoints and docs for the new model

## Testing
- `python -m py_compile run_api.py call_api.py`


------
https://chatgpt.com/codex/tasks/task_e_685bd5dde2008323a783f49352ed3de7