### PR TITLE
Replace generate_and_upscale endpoint with upscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Diffusion API
 
-This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
+This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` endpoint accepts a JSON body containing a `prompt` and an optional `seed`. The `/upscale` endpoint upscales an existing image sent as a base64 string.
 
 Generated images are cached on disk under `generated_images/`. When a request is made with the same prompt and seed combination, the API returns the cached image instead of re-running the model.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Diffusion API
 
-This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` endpoint accepts a JSON body containing a `prompt` and an optional `seed`. The `/upscale` endpoint upscales an existing image sent as a base64 string.
+This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` endpoint accepts a JSON body containing a `prompt` and an optional `seed`. The `/upscale` endpoint upscales a base64 image using the `stabilityai/stable-diffusion-x4-upscaler` model.
 
 Generated images are cached on disk under `generated_images/`. When a request is made with the same prompt and seed combination, the API returns the cached image instead of re-running the model.
 

--- a/call_api.py
+++ b/call_api.py
@@ -7,7 +7,7 @@ from io import BytesIO
 parser = argparse.ArgumentParser(description="Call the diffusion API")
 parser.add_argument("prompt", help="Text prompt for image generation")
 parser.add_argument("--seed", type=int, help="Optional seed for generation")
-parser.add_argument("--url", default="http://localhost:5000/generate_and_upscale", help="API URL")
+parser.add_argument("--url", default="http://localhost:5000/generate", help="API URL")
 
 args = parser.parse_args()
 
@@ -25,7 +25,7 @@ if response.status_code == 200:
     if "image_base64" in result:
         img_data = base64.b64decode(result["image_base64"])
         image = Image.open(BytesIO(img_data))
-        output_path = "generated_upscaled_api_image.png"
+        output_path = "generated_api_image.png"
         image.save(output_path)
         print(f"Image successfully generated and saved to {output_path}")
         if "seed" in result:


### PR DESCRIPTION
## Summary
- remove `generate_and_upscale` endpoint
- add `/upscale` endpoint for upscaling a base64 image
- adjust helper script and docs for the new endpoints

## Testing
- `python -m py_compile run_api.py call_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685be36db64c8323923b97abf81609f8