### PR TITLE
Replace Flux with OmniGen2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Diffusion API
 
-This repository provides a simple Flask API for generating images using the FLUX diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
+This repository provides a simple Flask API for generating images using the **OmniGen2** diffusion model. The `/generate` and `/generate_and_upscale` endpoints accept a JSON body containing a `prompt` and an optional `seed`.
 
 Generated images are cached on disk under `generated_images/`. When a request is made with the same prompt and seed combination, the API returns the cached image instead of re-running the model.
+
+The API loads the model weights from the Hugging Face repository `OmniGen2/OmniGen2` on startup.
 
 Run the API with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ torch==2.7.1
 torchvision==0.22.0
 torchaudio==2.7.1
 accelerate==0.31.0
-bitsandbytes==0.43.1
-sentencepiece==0.2.0
+einops==0.7.0
+timm==0.9.12
 Pillow==10.3.0


### PR DESCRIPTION
## Summary
- replace Flux references with OmniGen2 pipeline
- remove quantization/bitsandbytes logic
- simplify requirements for OmniGen2
- update documentation to mention OmniGen2

## Testing
- `python -m py_compile run_api.py call_api.py`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_685c19030450832391a56e7df564de05